### PR TITLE
Add build-date metadata

### DIFF
--- a/.github/workflows/docker-publication.yml
+++ b/.github/workflows/docker-publication.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Build the Docker image
       env:
         RELEASE_VERSION: ${{ steps.vars.outputs.tag }}
-      run: docker build . --file Dockerfile --tag ulisesgascon/development-toolkit:$RELEASE_VERSION --tag ulisesgascon/development-toolkit:latest
+      run: docker build --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') --file Dockerfile --tag ulisesgascon/development-toolkit:$RELEASE_VERSION --tag ulisesgascon/development-toolkit:latest .
       
     - name: Docker Push
       run: docker push --all-tags ulisesgascon/development-toolkit

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -10,4 +10,4 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Build container image
-      run: docker build -t ulisesgascon/development-toolkit:latest .
+      run: docker build --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') -t ulisesgascon/development-toolkit:latest .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
-# Start from an Ubuntu image
 FROM ubuntu:20.04
 
 # Metadata
 LABEL maintainer="ulises@linux.com"
+
+ARG BUILD_DATE
+LABEL org.label-schema.build-date=$BUILD_DATE
 
 # Install curl, git, net-tools and Docker
 RUN apt-get update && apt-get install -y curl git net-tools docker.io


### PR DESCRIPTION
### Main Changes

- Add `org.label-schema.build-date` metadata label (6c9def4)
- Add `BUILD_DATE` environmental variable to the CI pipelines (c34ae3c)

### Changelog

- 6c9def4 feat: add build-date metadata by @UlisesGascon
- c34ae3c feat: add BUILD_DATE environmental variable to the CI pipelines by @UlisesGascon
