### PR TITLE
add dynamic metadata labels

### DIFF
--- a/.github/workflows/docker-publication.yml
+++ b/.github/workflows/docker-publication.yml
@@ -35,7 +35,6 @@ jobs:
     - name: Build the Docker image
       env:
         RELEASE_VERSION: ${{ steps.vars.outputs.tag }}
-      run: docker build --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') --file Dockerfile --tag ulisesgascon/development-toolkit:$RELEASE_VERSION --tag ulisesgascon/development-toolkit:latest .
-      
+      run: docker build --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') --build-arg BUILD_VERSION=$RELEASE_VERSION --build-arg VCS_REF=$GITHUB_SHA --file Dockerfile --tag ulisesgascon/development-toolkit:$RELEASE_VERSION --tag ulisesgascon/development-toolkit:latest .
     - name: Docker Push
       run: docker push --all-tags ulisesgascon/development-toolkit

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -10,4 +10,4 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Build container image
-      run: docker build --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') -t ulisesgascon/development-toolkit:latest .
+      run: docker build --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') --build-arg BUILD_VERSION=$GITHUB_SHA --build-arg VCS_REF=$GITHUB_SHA -t ulisesgascon/development-toolkit:latest .

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ FROM ubuntu:20.04
 LABEL maintainer="ulises@linux.com"
 
 ARG BUILD_DATE
+ARG VCS_REF
+ARG BUILD_VERSION
+
 LABEL org.label-schema.schema-version="1.0"
 LABEL org.label-schema.name="ulisesgascon/development-toolkit"
 LABEL org.label-schema.description="Personal Docker image used for development"
@@ -11,6 +14,8 @@ LABEL org.label-schema.url="https://github.com/UlisesGascon/dockerized-developme
 LABEL org.label-schema.vcs-url="https://github.com/UlisesGascon/dockerized-development-toolkit"
 LABEL org.label-schema.vendor="Ulises Gascon"
 LABEL org.label-schema.docker.cmd="docker run -it ulisesgascon/development-toolkit:latest bash"
+LABEL org.label-schema.vcs-ref=$VCS_REF
+LABEL org.label-schema.version=$BUILD_VERSION
 LABEL org.label-schema.build-date=$BUILD_DATE
 
 # Install curl, git, net-tools and Docker


### PR DESCRIPTION
### Main Changes

- Add `org.label-schema` labels for (`vcs-ref`, `version`) (9d6677c)
- Add Build arguments for `VCS_REF` and `BUILD_VERSION` in CI pipelines (9d6677c)

### Changelog

- 9d6677c feat: add dynamic metadata labels by @UlisesGascon